### PR TITLE
Fix GitHub Pages deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,37 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Upload site artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: github-pages
+          path: ./index.html
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # tracker
+
+This repository automatically deploys `index.html` to GitHub Pages whenever changes land on the `main` branch. The workflow uploads the file as an artifact and publishes it using `actions/deploy-pages`.


### PR DESCRIPTION
## Summary
- simplify the workflow
- upload `index.html` as an artifact and deploy with `actions/deploy-pages`
- clarify deployment instructions in README

## Testing
- `git log -1 --stat`